### PR TITLE
fix: correct PohodaSer autoload path and add package dependency

### DIFF
--- a/debian/autoload.php
+++ b/debian/autoload.php
@@ -6,7 +6,7 @@ require_once '/usr/share/php/Composer/InstalledVersions.php';
 require_once '/usr/share/php/Ease/autoload.php';
 require_once '/usr/share/php/Lightools/Xml/autoload.php';
 require_once '/usr/share/php/Riesenia/Pohoda/autoload.php';
-require_once '/usr/share/php/PohodaSer/autoload.php';
+require_once '/usr/share/php/Pohoda/autoload.php';
 
 spl_autoload_register(function (string $class): void {
     $prefix = 'mServer\\';

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Package: php-vitexsoftware-pohoda-connector
 Architecture: all
 Multi-Arch: foreign
 Section: php
-Depends: ${misc:Depends}, ${phpcomposer:Depends}, ${php:Depends}, php-curl, php-xml, php-lightools-xml, composer
+Depends: ${misc:Depends}, ${phpcomposer:Depends}, ${php:Depends}, php-curl, php-xml, php-lightools-xml, php-vitexsoftware-pohodaser, composer
 Provides: php-pohoda
 Description: client library for Sormware's Pohoda mServer
     PHP library for communication with Pohoda mServer.


### PR DESCRIPTION
## Summary

- Fixed `debian/autoload.php` line 9: `PohodaSer/autoload.php` → `Pohoda/autoload.php` to match the actual install path of `php-vitexsoftware-pohodaser` (which uses the `Pohoda\` namespace)
- Added `php-vitexsoftware-pohodaser` to `Depends` in `debian/control` to declare the dependency explicitly

## Problem

Production server (`se-zabbix-proxy`) was throwing:
```
PHP Fatal error: Uncaught Error: Failed opening required '/usr/share/php/PohodaSer/autoload.php'
  in /usr/share/php/mServer/autoload.php on line 9
```

The mServer autoload template referenced `PohodaSer/` but `php-vitexsoftware-pohodaser` installs its autoload to `Pohoda/` (matching its `Pohoda\` PHP namespace per Debian PHP packaging conventions).

## Test plan

- [ ] Build package and verify `/usr/share/php/mServer/autoload.php` contains `require_once '/usr/share/php/Pohoda/autoload.php'`
- [ ] Install on test system with `php-vitexsoftware-pohodaser` present and confirm no fatal errors
- [ ] Verify `pohoda-raiffeisenbank` scripts load cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Debian package dependencies for the Pohoda connector: added the lightools XML library as a required dependency while removing the direct Composer requirement, simplifying package configuration and reducing external installation requirements
  * Corrected the autoloader configuration path to properly reference the Pohoda library from its system installation location, ensuring correct library loading

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/VitexSoftware/PHP-Pohoda-Connector/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->